### PR TITLE
Pull request for Issue  #24

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -143,6 +143,7 @@ p {
 /* repos */
 .repo-card {
   margin: auto;
+  margin: 20px;
 }
 
 .assoc-repo {

--- a/index.html
+++ b/index.html
@@ -273,7 +273,6 @@
           </div>
         </div>
       </div>
-      <br />
       <div class="row">
         <div class="col-lg-4">
           <div class="repo-card card" style="width: 18rem">
@@ -346,7 +345,6 @@
           </div>
         </div>
       </div>
-      <br />
       <div class="row">
         <div class="col-lg-4">
           <div class="repo-card card" style="width: 18rem">


### PR DESCRIPTION
<b><h2>Issue -</h2></b> "Associated Repository" Cards did not had proper margin when viewed in mobile.

<b><h2>Cause of issue -</h2></b> A break after every 3 columns was present which made margin to appear after every 3 columns in mobile view but, column containing "repo-card" did not had any margin-bottom present due to which they look compacted.

<b><h3>Reference Image (before) -</h3></b>
![1601973610956](https://user-images.githubusercontent.com/37269403/95227260-872dd880-081b-11eb-9913-c2d282f66ebe.JPEG)
  
<b><h2>How Issue resolved -</h2></b> By Adding margin-bottom in cards and removing line-break.

<b><h3>Reference Image (After)-</h3></b>
![Screenshot from 2020-10-06 21-24-03](https://user-images.githubusercontent.com/37269403/95227479-c8be8380-081b-11eb-9f81-a48bd3aaa545.png)
