### PR TITLE
Fix the card size of Associated repos and change the color of the Conditions apply text.

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -222,6 +222,10 @@ span {
   color: #fff;
 }
 
+.conditions{
+  color: #eeecda;
+}
+
 /* Call to Action */
 
 #cta {

--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
       <br /><br />
       <div class="row">
         <div class="col-lg-4">
-          <div class="repo-card card" style="width: 18rem">
+          <div class="repo-card card">
             <div class="card-body">
               <h5 class="card-title">skill-board</h5>
               <h6 class="card-subtitle mb-2 text-muted">HTML, JS, CSS</h6>
@@ -232,7 +232,7 @@
           </div>
         </div>
         <div class="col-lg-4">
-          <div class="repo-card card" style="width: 18rem">
+          <div class="repo-card card">
             <div class="card-body">
               <h5 class="card-title">devscollab.github.io</h5>
               <h6 class="card-subtitle mb-2 text-muted">HTML, JS, CSS</h6>
@@ -256,7 +256,7 @@
           </div>
         </div>
         <div class="col-lg-4">
-          <div class="repo-card card" style="width: 18rem">
+          <div class="repo-card card">
             <div class="card-body">
               <h5 class="card-title">skill-board-api</h5>
               <h6 class="card-subtitle mb-2 text-muted">Node.js, MongoDB</h6>
@@ -278,7 +278,7 @@
       </div>
       <div class="row">
         <div class="col-lg-4">
-          <div class="repo-card card" style="width: 18rem">
+          <div class="repo-card card">
             <div class="card-body">
               <h5 class="card-title">hacktoberfest</h5>
               <h6 class="card-subtitle mb-2 text-muted">HTML, JS, CSS</h6>
@@ -302,7 +302,7 @@
           </div>
         </div>
         <div class="col-lg-4">
-          <div class="repo-card card" style="width: 18rem">
+          <div class="repo-card card">
             <div class="card-body">
               <h5 class="card-title">expenses-flutter-app</h5>
               <h6 class="card-subtitle mb-2 text-muted">Android, Flutter</h6>
@@ -325,7 +325,7 @@
           </div>
         </div>
         <div class="col-lg-4">
-          <div class="repo-card card" style="width: 18rem">
+          <div class="repo-card card">
             <div class="card-body">
               <h5 class="card-title">all-calc</h5>
               <h6 class="card-subtitle mb-2 text-muted">Python</h6>
@@ -350,7 +350,7 @@
       </div>
       <div class="row">
         <div class="col-lg-4">
-          <div class="repo-card card" style="width: 18rem">
+          <div class="repo-card card">
             <div class="card-body">
               <h5 class="card-title">ml-opensource</h5>
               <h6 class="card-subtitle mb-2 text-muted">ML, Flask</h6>


### PR DESCRIPTION
Previously, the associated repos card size was small due to which the skill-board card was looking like this.
![image](https://user-images.githubusercontent.com/51946123/95424224-f4e31d00-095f-11eb-90c2-038d05fb3a8e.png)

I have rectified this issue and now the card is looking as shown below.
![image](https://user-images.githubusercontent.com/51946123/95424304-10e6be80-0960-11eb-8cf7-5869cdc6a174.png)

I have also changed the color of the conditions text and now it's looking like this.
![image](https://user-images.githubusercontent.com/51946123/95424408-35429b00-0960-11eb-8827-57b72e75652c.png)

Please check.
