### PR TITLE
Allign the cards of associated repositories in mobile view

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -127,7 +127,6 @@ p {
 #global-stats {
   padding: 7% 15%;
   background-color: #fff;
-  position: relative;
 }
 
 .global-stats-row {
@@ -135,16 +134,13 @@ p {
   padding: 5%;
 }
 
+.card-body{
+  text-align:left;
+}
+
 .icon {
   color: #072540;
   margin-bottom: 1rem;
-}
-
-@media (max-width: 1028px){
-#global-stats .card{
-  position:relative;
-  left:170px;
-}
 }
 
 /* repos */

--- a/css/styles.css
+++ b/css/styles.css
@@ -140,6 +140,13 @@ p {
   margin-bottom: 1rem;
 }
 
+@media (max-width: 1028px){
+#global-stats .card{
+  position:relative;
+  left:170px;
+}
+}
+
 /* repos */
 .repo-card {
   margin: auto;

--- a/index.html
+++ b/index.html
@@ -205,6 +205,7 @@
     <section id="global-stats">
       <h3 class="global-stats-header">Associated Repositories</h3>
       <br /><br />
+      <center>
       <div class="row">
         <div class="col-lg-4">
           <div class="repo-card card">
@@ -276,6 +277,7 @@
           </div>
         </div>
       </div>
+    
       <div class="row">
         <div class="col-lg-4">
           <div class="repo-card card">
@@ -374,6 +376,7 @@
           </div>
         </div>
       </div>
+    </center>
     </section>
 
     <!-- Fest Info -->


### PR DESCRIPTION
Issue: #29
Added CSS for responsiveness of the associated repositories cards.
![image](https://user-images.githubusercontent.com/45139641/95769034-da4cd300-0cd4-11eb-98f3-80b4ac962fa7.png)
